### PR TITLE
Update golint path #9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ INTEGRATION  := $(shell basename $(shell pwd))
 BINARY_NAME   = $(INTEGRATION)
 GO_PKGS      := $(shell go list ./... | grep -v "/vendor/")
 GO_FILES     := $(shell find src -type f -name "*.go")
-VALIDATE_DEPS = github.com/golang/lint/golint
+VALIDATE_DEPS = golang.org/x/lint/golint
 DEPS          = github.com/kardianos/govendor
 TEST_DEPS     = github.com/axw/gocov/gocov github.com/AlekSi/gocov-xml
 


### PR DESCRIPTION
#9 
goint path changes to current path `golang.org/x/lint/golint` .